### PR TITLE
Add information about backing file name & path

### DIFF
--- a/ctld_exporter.go
+++ b/ctld_exporter.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
 
 	"github.com/Gandi/ctld_exporter/ctlstats"
@@ -17,17 +18,17 @@ var (
 	ioBytesDesc = prometheus.NewDesc(
 		"iscsi_target_bytes",
 		"Number of bytes",
-		[]string{"type", "target", "lun", "file"}, nil,
+		[]string{"type", "target", "lun", "filepath", "filename"}, nil,
 	)
 	ioOperationsDesc = prometheus.NewDesc(
 		"iscsi_target_operations",
 		"Number of operations",
-		[]string{"type", "target", "lun", "file"}, nil,
+		[]string{"type", "target", "lun", "filepath", "filename"}, nil,
 	)
 	ioDmasDesc = prometheus.NewDesc(
 		"iscsi_target_dmas",
 		"Number of DMA",
-		[]string{"type", "target", "lun", "file"}, nil,
+		[]string{"type", "target", "lun", "filepath", "filename"}, nil,
 	)
 	initiatorsNumberDesc = prometheus.NewDesc(
 		"iscsi_target_initiators",
@@ -65,47 +66,47 @@ func (ic iscsiCollector) Collect(ch chan<- prometheus.Metric) {
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun, file)
+			"NO IO", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun, file)
+			"READ", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun, file)
+			"WRITE", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun, file)
+			"NO IO", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun, file)
+			"READ", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun, file)
+			"WRITE", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun, file)
+			"NO IO", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun, file)
+			"READ", target, stringlun, file, filepath.Base(file))
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun, file)
+			"WRITE", target, stringlun, file, filepath.Base(file))
 	}
 	ch <- dropped
 	for _, target := range targets.Targets {

--- a/ctld_exporter.go
+++ b/ctld_exporter.go
@@ -2,31 +2,32 @@
 package main
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/Gandi/ctld_exporter/ctlstats"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"net/http"
-	"strconv"
 )
 
 var (
 	ioBytesDesc = prometheus.NewDesc(
 		"iscsi_target_bytes",
 		"Number of bytes",
-		[]string{"type", "target", "lun"}, nil,
+		[]string{"type", "target", "lun", "file"}, nil,
 	)
 	ioOperationsDesc = prometheus.NewDesc(
 		"iscsi_target_operations",
 		"Number of operations",
-		[]string{"type", "target", "lun"}, nil,
+		[]string{"type", "target", "lun", "file"}, nil,
 	)
 	ioDmasDesc = prometheus.NewDesc(
 		"iscsi_target_dmas",
 		"Number of DMA",
-		[]string{"type", "target", "lun"}, nil,
+		[]string{"type", "target", "lun", "file"}, nil,
 	)
 	initiatorsNumberDesc = prometheus.NewDesc(
 		"iscsi_target_initiators",
@@ -44,6 +45,8 @@ func (ic iscsiCollector) Describe(ch chan<- *prometheus.Desc) {
 func (ic iscsiCollector) Collect(ch chan<- prometheus.Metric) {
 	dataByLun := ctlstats.GetStats()
 	targets := ctlstats.GetTargets()
+	devLuns := ctlstats.GetDevLuns()
+
 	dropped := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "iscsi_unknown_target",
 		Help: "Current number of unkown targets/lun",
@@ -55,53 +58,54 @@ func (ic iscsiCollector) Collect(ch chan<- prometheus.Metric) {
 			dropped.Inc()
 			continue
 		}
+		file, err := devLuns.GetFile(uint(lun))
 		stringlun := strconv.FormatUint(uint64(lunid), 10)
 		target := targets.GetLunTarget(uint(lun)).Name
 		ch <- prometheus.MustNewConstMetric(
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun)
+			"NO IO", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun)
+			"READ", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioBytesDesc,
 			prometheus.CounterValue,
 			float64(data.Bytes[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun)
+			"WRITE", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun)
+			"NO IO", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun)
+			"READ", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioOperationsDesc,
 			prometheus.CounterValue,
 			float64(data.Operations[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun)
+			"WRITE", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_NO_IO]),
-			"NO IO", target, stringlun)
+			"NO IO", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_READ]),
-			"READ", target, stringlun)
+			"READ", target, stringlun, file)
 		ch <- prometheus.MustNewConstMetric(
 			ioDmasDesc,
 			prometheus.CounterValue,
 			float64(data.Dmas[ctlstats.CTL_STATS_WRITE]),
-			"WRITE", target, stringlun)
+			"WRITE", target, stringlun, file)
 	}
 	ch <- dropped
 	for _, target := range targets.Targets {

--- a/ctlstats/ctlstats.go
+++ b/ctlstats/ctlstats.go
@@ -274,13 +274,6 @@ func (cp CtlPortList) GetLunId(lunNumber uint) (uint, error) {
 	}
 
 	return 0, errors.New("Unkown LUN in target")
-
-	// for _, lun := range cp.GetLunTarget(lunNumber).LUN {
-	// 	if lun.LunNumber == lunNumber {
-	// 		return lun.Id, nil
-	// 	}
-	// }
-	// return 0, errors.New("Unkown LUN in target")
 }
 
 func (cp CtlLunList) GetFile(lunNumber uint) (string, error) {


### PR DESCRIPTION
This commit allow to extract backing file name and expose in Grafana Dashboard.

**Use case:**
We use Proxmox visualization with storage server powered by FreeBSD. KVM machines connect to ZVOLs via iscsi. There are thousand of ZVOL in one target and it's working fine.   

Actual dashboard contains only LUN numbers, but backing file name contains VM number & disk ID inside VM, so file name is more useful. 

Here is example (snippet of output):

```
iscsi_target_bytes{filename="vm-853-disk-0",filepath="/dev/zvol/nvmetank/vm-853-disk-0",lun="1250",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="WRITE"} 6.1219584e+08
iscsi_target_bytes{filename="vm-853-disk-1",filepath="/dev/zvol/nvmetank/vm-853-disk-1",lun="1260",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="NO IO"} 0
iscsi_target_bytes{filename="vm-853-disk-1",filepath="/dev/zvol/nvmetank/vm-853-disk-1",lun="1260",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="READ"} 3.6734026496e+10
iscsi_target_bytes{filename="vm-853-disk-1",filepath="/dev/zvol/nvmetank/vm-853-disk-1",lun="1260",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="WRITE"} 8.67211965952e+11
iscsi_target_bytes{filename="vm-854-cloudinit",filepath="/dev/zvol/nvmetank/vm-854-cloudinit",lun="1233",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="NO IO"} 0
iscsi_target_bytes{filename="vm-854-cloudinit",filepath="/dev/zvol/nvmetank/vm-854-cloudinit",lun="1233",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="READ"} 560704
iscsi_target_bytes{filename="vm-854-cloudinit",filepath="/dev/zvol/nvmetank/vm-854-cloudinit",lun="1233",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="WRITE"} 729088
iscsi_target_bytes{filename="vm-854-disk-0",filepath="/dev/zvol/nvmetank/vm-854-disk-0",lun="1234",target="iqn.2012-06.ru.postgrespro.gigastorage5:target0",type="NO IO"} 0
```

Also I tried to reduce CPU consumption by addition index, but this commit may be reverted. 

Thank you for exporter! 